### PR TITLE
Fix location link on DC page

### DIFF
--- a/dc/index.html
+++ b/dc/index.html
@@ -49,7 +49,7 @@
             In the spring, summer, and fall, the location alternates between
             <a href="https://www.dclibrary.org/plan-visit/martin-luther-king-jr-memorial-library/labs">The Labs</a>
             at the MLK Library (DCPL Central Library), and
-            <a href="">Temperance Alley Garden</a>.
+            <a href="https://www.instagram.com/tempgardendc">Temperance Alley Garden</a>.
             In the winter, most meetups happen in at The Labs, with some
             happening in the upstairs meeting rooms of the
             <a href="https://www.dclibrary.org/plan-visit/martin-luther-king-jr-memorial-library">MLK Library</a>.


### PR DESCRIPTION
This updates the DC club page to add a URL to a link that previously had no effect.